### PR TITLE
Fix set privacy status

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,9 @@ jobs:
       with:
         java-version: 1.8
 
+    - name: Setup Android SDK
+      uses: android-actions/setup-android@v2
+
     - name: Install cordova
       run: sudo npm install -g cordova
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,9 +38,6 @@ jobs:
       with:
         java-version: 1.8
 
-    - name: Setup Android SDK
-      uses: android-actions/setup-android@v2
-
     - name: Install cordova
       run: sudo npm install -g cordova
 
@@ -53,6 +50,6 @@ jobs:
 
     - name: build android and ios
       run: |
-        cordova-paramedic --platform android --plugin . --justbuild --verbose
+        cordova-paramedic --platform android@8.0.0 --plugin . --justbuild --verbose
         cordova-paramedic --platform ios --plugin . --justbuild --verbose --timeout 900000
 

--- a/src/ios/ACPCore_Cordova.m
+++ b/src/ios/ACPCore_Cordova.m
@@ -150,7 +150,7 @@
 
 - (void) setLogLevel:(CDVInvokedUrlCommand*)command {
     [self.commandDelegate runInBackground:^{
-        ACPMobileLogLevel logLevel = (ACPMobileLogLevel)[self getCommandArg:command.arguments[0]];
+        ACPMobileLogLevel logLevel = (ACPMobileLogLevel)[[self getCommandArg:command.arguments[0]] intValue];
 
         [ACPCore setLogLevel:logLevel];
 

--- a/src/ios/ACPCore_Cordova.m
+++ b/src/ios/ACPCore_Cordova.m
@@ -161,7 +161,7 @@
 
 - (void) setPrivacyStatus:(CDVInvokedUrlCommand*)command {
     [self.commandDelegate runInBackground:^{
-        ACPMobilePrivacyStatus privacyStatus = (ACPMobilePrivacyStatus)[self getCommandArg:command.arguments[0]];
+        ACPMobilePrivacyStatus privacyStatus = (ACPMobilePrivacyStatus)[[self getCommandArg:command.arguments[0]] intValue];
 
         [ACPCore setPrivacyStatus:privacyStatus];
 

--- a/tests/tests.js
+++ b/tests/tests.js
@@ -95,9 +95,9 @@ exports.defineAutoTests = function() {
             ACPCore.getPrivacyStatus(function() {}, "error")
             expect(console.log).toHaveBeenCalled();
         });
-        it('check if the result is a string', function(done) {
+        it('check if the result is a number', function(done) {
             ACPCore.getPrivacyStatus(function(result) {
-                expect(typeof result === "string").toBe(true);
+                expect(typeof result === "number").toBe(true);
                 done();
             }, function() {});
         })


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
- Fix for https://github.com/adobe/cordova-acpcore/issues/9. Converting the NSNumber contained in the cordova argument array to an `int` allows the casting to ACPMobilePrivacyStatus to be successful.
<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](http://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
